### PR TITLE
Refactor HandoverExperiment.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(monadcount-sim LANGUAGES CXX)
 
+option(WITH_NETANIM "Build with NetAnim support" OFF)
+
 # Use C++20
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -18,9 +20,9 @@ find_package(ns3 REQUIRED
         PATHS ${NS3_CMAKE_DIR}
         NO_DEFAULT_PATH  # Avoid using system-wide ns-3 installations
 )
-
-add_subdirectory(${CMAKE_SOURCE_DIR}/extern/netanim)
-
+if(WITH_NETANIM)
+    add_subdirectory(${CMAKE_SOURCE_DIR}/extern/netanim)
+endif()
 # =======================================================================
 # Project Subdirectories
 # =======================================================================
@@ -46,13 +48,17 @@ target_link_libraries(monadcount_sim
         ns3::mobility
         ns3::applications
         ns3::wifi
-        ns3::netanim
 
         # Simulation libraries:
         monadcount_sim::factories_pedestrians
         monadcount_sim::core
         monadcount_sim_experiments
 )
+
+if(WITH_NETANIM)
+    target_link_libraries(monadcount_sim PRIVATE ns3::netanim)
+    target_compile_definitions(monadcount_sim PRIVATE WITH_NETANIM)
+endif()
 
 # =======================================================================
 # Runtime Output & Custom Targets

--- a/src/experiments/BasicExperiment.cpp
+++ b/src/experiments/BasicExperiment.cpp
@@ -1,5 +1,8 @@
 // NS-3 Simulation: Pedestrian Wi-Fi Mobility with Association and RSSI
+#ifdef WITH_NETANIM
 #include <ns3/animation-interface.h>
+#endif
+
 #include "BasicExperiment.hpp"
 #include "ns3/core-module.h"
 #include "ns3/network-module.h"
@@ -216,8 +219,10 @@ void BasicExperiment::Run(monadcount_sim::core::ScenarioEnvironment &env)
 
     phy2.SetPcapDataLinkType (YansWifiPhyHelper::DLT_IEEE802_11_RADIO);
     phy2.EnablePcap("data/basic/ap2", apDevice2);
-    AnimationInterface anim("data/basic/netanim.xml");
-    anim.SetMaxPktsPerTraceFile(500000);
+    #ifdef WITH_NETANIM
+        AnimationInterface anim("data/basic/netanim.xml");
+        anim.SetMaxPktsPerTraceFile(500000);
+    #endif
 
     // --------------------------------------------------
     // 8) Run

--- a/src/experiments/CMakeLists.txt
+++ b/src/experiments/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(monadcount_sim_experiments
         BasicExperiment.cpp
         DoorToDoorExperiment.cpp
         HandoverExperiment.cpp
-        GaussMarkovHandoverExperiment.cpp
+
 )
 
 target_include_directories(monadcount_sim_experiments PUBLIC

--- a/src/experiments/GaussMarkovHandoverExperiment.cpp
+++ b/src/experiments/GaussMarkovHandoverExperiment.cpp
@@ -63,9 +63,11 @@ GaussMarkovHandoverExperiment::SetupMobility()
 void
 GaussMarkovHandoverExperiment::SetupTracing()
 {
+    #ifdef WITH_NETANIM
     m_anim = new AnimationInterface( "data/gauss-markov-handover/netanim.xml");
     m_anim->UpdateNodeColor(m_wifiApNodes.Get(0)->GetId(), 0, 0, 255);
     m_anim->UpdateNodeColor(m_wifiApNodes.Get(1)->GetId(), 255, 0, 0);
+    #endif
 
     YansWifiPhyHelper wifiPhyHelper;
     for (uint32_t i = 0; i < m_apDevices.GetN(); ++i)

--- a/src/experiments/HandoverExperiment.cpp
+++ b/src/experiments/HandoverExperiment.cpp
@@ -1,32 +1,47 @@
 #include "HandoverExperiment.hpp"
-#include "ns3/animation-interface.h"
+
+#ifdef WITH_NETANIM
+#include <ns3/animation-interface.h>
+#endif
+
 #include "ns3/ipv4-global-routing-helper.h"
 #include <cmath>
 #include <string>
 #include <map>
+#include <vector>
 
 using namespace ns3;
 
 NS_LOG_COMPONENT_DEFINE("HandoverExperiment");
 
+// Tweak parameters as needed
 HandoverExperiment::HandoverExperiment ()
-        : m_numPedestrians(10),
+        : m_numAp(5),
+          m_numPedestrians(25),
           m_simulationTime(60.0),
           m_roomLength(50.0),
           m_roomWidth(30.0),
           m_handoverMargin(5.0),
           m_txPower_dBm(20.0),
           m_pathLossExponent(3.0),
+          // Mobility model: ConstantVelocity|RandomWalk2d|GaussMarkov|Waypoint
+          m_mobilityModel("GaussMarkov"),
           m_anim(nullptr)
 {
-    // The maps m_nodeAssociation and m_nodeTriggered are initialized later in SetupNodes.
 }
 
 void
 HandoverExperiment::Run(monadcount_sim::core::ScenarioEnvironment &env)
 {
+    /*
+    CommandLine cmd;
+    cmd.AddValue("nAp",      "Number of APs",          m_numAp);
+    cmd.AddValue("nPed",     "Total pedestrians",      m_numPedestrians);
+    cmd.AddValue("mobModel", "Mobility model: ConstantVelocity|RandomWalk2d|GaussMarkov|Waypoint",
+                 m_mobilityModel);
+    cmd.Parse();
+    */
     NS_LOG_INFO("Setting up RSSI-based Handover Experiment...");
-
     SetupNodes();
     SetupWifi();
     SetupMobility();
@@ -34,8 +49,20 @@ HandoverExperiment::Run(monadcount_sim::core::ScenarioEnvironment &env)
     SetupApplications();
     SetupTracing();
 
-    // Schedule the periodic per-node handover and color update.
-    Simulator::Schedule(Seconds(1.0), &HandoverExperiment::CheckRssiAndTriggerHandover, this);
+    // Schedule handover checks
+    Simulator::Schedule(Seconds(1.0),
+                        &HandoverExperiment::CheckRssiAndTriggerHandover,
+                        this);
+
+    // At end, dump summary
+    Simulator::Schedule(Seconds(m_simulationTime + 0.1), [this]() {
+        NS_LOG_UNCOND("=== Handover Summary per Node ===");
+        for (auto &kv : m_handoverCount) {
+            NS_LOG_UNCOND(" Node " << kv.first
+                                   << " performed " << kv.second
+                                   << " handovers");
+        }
+    });
 
     Simulator::Stop(Seconds(m_simulationTime));
     NS_LOG_INFO("Running Handover Simulation...");
@@ -49,139 +76,181 @@ HandoverExperiment::EstimateRssi(const Vector &stationPos, const Vector &apPos) 
 {
     double dx = stationPos.x - apPos.x;
     double dy = stationPos.y - apPos.y;
-    double distance = std::sqrt(dx * dx + dy * dy);
-    if (distance < 1.0)
-    {
-        distance = 1.0;
-    }
-    return m_txPower_dBm - 10.0 * m_pathLossExponent * std::log10(distance);
+    double dist = std::sqrt(dx*dx + dy*dy);
+    if (dist < 1.0) dist = 1.0;
+    return m_txPower_dBm - 10.0 * m_pathLossExponent * std::log10(dist);
 }
 
 void
 HandoverExperiment::SetupNodes()
 {
-    // Create AP nodes.
-    m_wifiApNodes.Create(2);
+    // Create APs
+    m_wifiApNodes.Create(m_numAp);
 
-    // Divide pedestrians into two groups.
-    uint32_t numGroupA = m_numPedestrians / 2;
-    uint32_t numGroupB = m_numPedestrians - numGroupA;
-    m_groupA.Create(numGroupA);
-    m_groupB.Create(numGroupB);
+    // Divide pedestrians evenly into groups
+    uint32_t perGroup = m_numPedestrians / m_numAp;
+    uint32_t rem      = m_numPedestrians % m_numAp;
+    m_groups.resize(m_numAp);
 
-    // Initialize per-node association and triggered maps.
-    for (uint32_t i = 0; i < m_groupA.GetN(); ++i) {
-        uint32_t nodeId = m_groupA.Get(i)->GetId();
-        m_nodeAssociation[nodeId] = 1; // Group A initially with AP1.
-        m_nodeTriggered[nodeId] = false;
-    }
-    for (uint32_t i = 0; i < m_groupB.GetN(); ++i) {
-        uint32_t nodeId = m_groupB.Get(i)->GetId();
-        m_nodeAssociation[nodeId] = 2; // Group B initially with AP2.
-        m_nodeTriggered[nodeId] = false;
+    for (uint32_t i = 0; i < m_numAp; ++i) {
+        uint32_t cnt = perGroup + (i == m_numAp-1 ? rem : 0);
+        m_groups[i].Create(cnt);
+        for (uint32_t j = 0; j < cnt; ++j) {
+            uint32_t id = m_groups[i].Get(j)->GetId();
+            m_nodeAssociation[id] = i;
+            m_nodeTriggered [id] = false;
+            m_handoverCount [id] = 0;
+        }
     }
 }
 
 void
 HandoverExperiment::SetupWifi()
 {
-    // Create a single Wi-Fi channel with delay and propagation loss models.
-    YansWifiChannelHelper wifiChannel = YansWifiChannelHelper::Default();
-    wifiChannel.SetPropagationDelay("ns3::ConstantSpeedPropagationDelayModel");
-    wifiChannel.AddPropagationLoss("ns3::NakagamiPropagationLossModel");
-    YansWifiPhyHelper wifiPhy;
-    wifiPhy.SetChannel(wifiChannel.Create());
+    // Channel, PHY, MAC
+    YansWifiChannelHelper channel = YansWifiChannelHelper::Default();
+    channel.SetPropagationDelay("ns3::ConstantSpeedPropagationDelayModel");
+    channel.AddPropagationLoss("ns3::NakagamiPropagationLossModel");
+    YansWifiPhyHelper phy; phy.SetChannel(channel.Create());
 
     WifiHelper wifi;
     wifi.SetStandard(WIFI_STANDARD_80211g);
     wifi.SetRemoteStationManager("ns3::AarfWifiManager");
 
     Ssid ssid("eduroam");
-
-    // Install Wi-Fi devices on the AP nodes.
+    // APs
     WifiMacHelper macAp;
     macAp.SetType("ns3::ApWifiMac", "Ssid", SsidValue(ssid));
-    m_apDevices = wifi.Install(wifiPhy, macAp, m_wifiApNodes);
+    m_apDevices = wifi.Install(phy, macAp, m_wifiApNodes);
 
-    // Install Wi-Fi devices on pedestrian nodes.
+    // STAs
     WifiMacHelper macSta;
-    macSta.SetType("ns3::StaWifiMac", "Ssid", SsidValue(ssid), "ActiveProbing", BooleanValue(true));
-    m_staDevices = wifi.Install(wifiPhy, macSta, m_groupA);
-    NetDeviceContainer staDevicesB = wifi.Install(wifiPhy, macSta, m_groupB);
-    m_staDevices.Add(staDevicesB);
-
-    // Retrieve pointers to the AP MAC objects.
-    Ptr<WifiNetDevice> ap1Device = DynamicCast<WifiNetDevice>(m_apDevices.Get(0));
-    if (ap1Device)
-    {
-        m_ap1Mac = DynamicCast<ApWifiMac>(ap1Device->GetMac());
-    }
-    Ptr<WifiNetDevice> ap2Device = DynamicCast<WifiNetDevice>(m_apDevices.Get(1));
-    if (ap2Device)
-    {
-        m_ap2Mac = DynamicCast<ApWifiMac>(ap2Device->GetMac());
+    macSta.SetType("ns3::StaWifiMac",
+                   "Ssid", SsidValue(ssid),
+                   "ActiveProbing", BooleanValue(true));
+    for (auto &grp : m_groups) {
+        NetDeviceContainer d = wifi.Install(phy, macSta, grp);
+        m_staDevices.Add(d);
     }
 }
 
 void
 HandoverExperiment::SetupMobility()
 {
-    // (a) Set AP positions at opposite sides.
-    MobilityHelper mobilityAp;
-    mobilityAp.SetMobilityModel("ns3::ConstantPositionMobilityModel");
-    mobilityAp.Install(m_wifiApNodes);
-    Ptr<MobilityModel> apMob1 = m_wifiApNodes.Get(0)->GetObject<MobilityModel>();
-    apMob1->SetPosition(Vector(5.0, m_roomWidth / 2.0, 2.0)); // AP1 near left.
-    Ptr<MobilityModel> apMob2 = m_wifiApNodes.Get(1)->GetObject<MobilityModel>();
-    apMob2->SetPosition(Vector(45.0, m_roomWidth / 2.0, 2.0)); // AP2 near right.
-
-    // (b) Set pedestrian mobility.
-    // Group A: Starting at the left end, moving to the right.
-    MobilityHelper mobilityGroupA;
-    mobilityGroupA.SetMobilityModel("ns3::ConstantVelocityMobilityModel");
-    mobilityGroupA.SetPositionAllocator("ns3::RandomRectanglePositionAllocator",
-                                        "X", StringValue("ns3::UniformRandomVariable[Min=0.0|Max=10.0]"),
-                                        "Y", StringValue("ns3::UniformRandomVariable[Min=5.0|Max=25.0]"));
-    mobilityGroupA.Install(m_groupA);
-
-    // Group B: Starting at the right end, moving to the left.
-    MobilityHelper mobilityGroupB;
-    mobilityGroupB.SetMobilityModel("ns3::ConstantVelocityMobilityModel");
-    mobilityGroupB.SetPositionAllocator("ns3::RandomRectanglePositionAllocator",
-                                        "X", StringValue("ns3::UniformRandomVariable[Min=40.0|Max=50.0]"),
-                                        "Y", StringValue("ns3::UniformRandomVariable[Min=5.0|Max=25.0]"));
-    mobilityGroupB.Install(m_groupB);
-
-    // Create a uniform random variable stream for the y-axis velocity.
-    Ptr<UniformRandomVariable> uvA = CreateObject<UniformRandomVariable> ();
-    uvA->SetAttribute("Min", DoubleValue(-0.5));
-    uvA->SetAttribute("Max", DoubleValue(0.5));
-
-    Ptr<UniformRandomVariable> uvB = CreateObject<UniformRandomVariable> ();
-    uvB->SetAttribute("Min", DoubleValue(-0.5));
-    uvB->SetAttribute("Max", DoubleValue(0.5));
-
-    // Set individual velocities for Group A with random y component.
-    for (uint32_t i = 0; i < m_groupA.GetN(); ++i)
-    {
-        Ptr<ConstantVelocityMobilityModel> cvm = m_groupA.Get(i)->GetObject<ConstantVelocityMobilityModel>();
-        if (cvm)
-        {
-            double vy = uvA->GetValue(); // Random y velocity in [-0.5, 0.5]
-            // For Group A, x-velocity is 1.0 (moving right).
-            cvm->SetVelocity(Vector(1.0, vy, 0.0));
-        }
+    // 1) Place APs along the x‑axis, centered in y:
+    MobilityHelper mobAp;
+    mobAp.SetMobilityModel("ns3::ConstantPositionMobilityModel");
+    mobAp.Install(m_wifiApNodes);
+    for (uint32_t i = 0; i < m_numAp; ++i) {
+        double x = 5.0 + i * (m_roomLength - 10.0) / (m_numAp - 1);
+        m_wifiApNodes.Get(i)
+                ->GetObject<MobilityModel>()
+                ->SetPosition(Vector(x, m_roomWidth/2.0, 2.0));
     }
 
-    // Set individual velocities for Group B with random y component.
-    for (uint32_t i = 0; i < m_groupB.GetN(); ++i)
-    {
-        Ptr<ConstantVelocityMobilityModel> cvm = m_groupB.Get(i)->GetObject<ConstantVelocityMobilityModel>();
-        if (cvm)
-        {
-            double vy = uvB->GetValue(); // Random y velocity in [-0.5, 0.5]
-            // For Group B, x-velocity is -1.0 (moving left).
-            cvm->SetVelocity(Vector(-1.0, vy, 0.0));
+    // 2) Pedestrian groups
+    for (uint32_t i = 0; i < m_numAp; ++i) {
+        // each group starts in a 10‑m band on their AP side:
+        double xmin = (i == 0 ? 0.0 : m_roomLength - 10.0);
+        double xmax = (i == 0 ? 10.0 : m_roomLength);
+
+        MobilityHelper mobPed;
+        mobPed.SetPositionAllocator(
+                "ns3::RandomRectanglePositionAllocator",
+                "X", StringValue("ns3::UniformRandomVariable[Min=" +
+                                 std::to_string(xmin) + "|Max=" +
+                                 std::to_string(xmax) + "]"),
+                "Y", StringValue("ns3::UniformRandomVariable[Min=5.0|Max=25.0]"));
+
+        if (m_mobilityModel == "RandomWalk2d") {
+            // bias walk ±10° around due‑east or due‑west
+            double dirCenter = (i == 0 ? 0.0 : M_PI);
+            double delta    = M_PI / 18.0;
+            mobPed.SetMobilityModel(
+                    "ns3::RandomWalk2dMobilityModel",
+                    "Mode", StringValue("Time"),
+                    "Time", StringValue("2s"),
+                    "Speed", StringValue(
+                            "ns3::UniformRandomVariable[Min=0.5|Max=1.5]"),
+                    "Bounds", RectangleValue(
+                            Rectangle(0, m_roomLength, 0, m_roomWidth)),
+                    "Direction", StringValue(
+                            "ns3::UniformRandomVariable[Min=" +
+                            std::to_string(dirCenter - delta) +
+                            "|Max=" +
+                            std::to_string(dirCenter + delta) + "]"));
+        }
+        else if (m_mobilityModel == "GaussMarkov") {
+            mobPed.SetMobilityModel(
+                    "ns3::GaussMarkovMobilityModel",
+                    // how often the model updates
+                    "TimeStep",        TimeValue(Seconds(0.5)),
+                    // drift control (0 → pure randomness; 1 → pure drift)
+                    "Alpha",           DoubleValue(0.85),
+                    // constant speed of ±1 m/s
+                    "MeanVelocity",    StringValue(
+                            "ns3::UniformRandomVariable[Min=" +
+                            std::to_string(i==0?+1.0:-1.0) +
+                            "|Max=" +
+                            std::to_string(i==0?+1.0:-1.0) + "]"),
+                    // small Gaussian speed fluctuation around that mean
+                    "NormalVelocity",  StringValue(
+                            "ns3::NormalRandomVariable[Mean=0.0|Variance=0.1|Bound=0.5]"),
+                    // constant direction (0 = east, π = west)
+                    "MeanDirection",   StringValue(
+                            "ns3::ConstantRandomVariable[Constant=" +
+                            std::to_string(i==0?0.0:M_PI) + "]"),
+                    // small angular jitter
+                    "NormalDirection", StringValue(
+                            "ns3::NormalRandomVariable[Mean=0.0|Variance=0.05|Bound=0.2]")
+            );
+        }
+
+        else if (m_mobilityModel == "Waypoint") {
+            mobPed.SetMobilityModel("ns3::WaypointMobilityModel");
+        }
+        else {
+            // default: constant velocity toward the other AP
+            mobPed.SetMobilityModel("ns3::ConstantVelocityMobilityModel");
+        }
+
+        // install mobility on this group
+        mobPed.Install(m_groups[i]);
+
+        // 3) post‑install: seed velocities or waypoints
+        if (m_mobilityModel == "ConstantVelocity") {
+            auto urv = CreateObject<UniformRandomVariable>();
+            urv->SetAttribute("Min", DoubleValue(-0.5));
+            urv->SetAttribute("Max", DoubleValue( 0.5));
+            double vx = (i == 0 ? +1.0 : -1.0);
+            for (uint32_t j = 0; j < m_groups[i].GetN(); ++j) {
+                Ptr<ConstantVelocityMobilityModel> cvm =
+                        m_groups[i].Get(j)->GetObject<ConstantVelocityMobilityModel>();
+                cvm->SetVelocity(Vector(vx, urv->GetValue(), 0.0));
+            }
+        }
+        else if (m_mobilityModel == "Waypoint") {
+            auto urv = CreateObject<UniformRandomVariable>();
+            urv->SetAttribute("Min", DoubleValue(5.0));
+            urv->SetAttribute("Max", DoubleValue(m_roomWidth - 5.0));
+            for (uint32_t j = 0; j < m_groups[i].GetN(); ++j) {
+                Ptr<Node> node = m_groups[i].Get(j);
+                Ptr<WaypointMobilityModel> wpm =
+                        node->GetObject<WaypointMobilityModel>();
+                // start position at t=0
+                Vector p0 = node->GetObject<MobilityModel>()->GetPosition();
+                wpm->AddWaypoint(Waypoint(Seconds(0.0), p0));
+                // 25% time midpoint on opposite wall
+                Vector p1(
+                        (i == 0 ? m_roomLength - 5.0 : 5.0),
+                        urv->GetValue(), 2.0);
+                wpm->AddWaypoint(Waypoint(Seconds(m_simulationTime*0.25), p1));
+                // 75% time final waypoint
+                Vector p2(
+                        (i == 0 ? m_roomLength - 5.0 : 5.0),
+                        urv->GetValue(), 2.0);
+                wpm->AddWaypoint(Waypoint(Seconds(m_simulationTime*0.75), p2));
+            }
         }
     }
 }
@@ -191,74 +260,63 @@ HandoverExperiment::SetupInternet()
 {
     InternetStackHelper stack;
     stack.Install(m_wifiApNodes);
-    stack.Install(m_groupA);
-    stack.Install(m_groupB);
+    for (auto &grp : m_groups) stack.Install(grp);
 
-    Ipv4AddressHelper address;
-    address.SetBase("10.1.1.0", "255.255.255.0");
-
-    Ipv4InterfaceContainer apInterfaces = address.Assign(m_apDevices);
+    Ipv4AddressHelper addr;
+    addr.SetBase("10.1.1.0", "255.255.255.0");
+    addr.Assign(m_apDevices);
     Ipv4GlobalRoutingHelper::PopulateRoutingTables();
 }
 
 void
 HandoverExperiment::SetupApplications()
 {
-    uint16_t echoPort = 7;
-    UdpEchoServerHelper echoServer(echoPort);
-
-    ApplicationContainer serverApp1 = echoServer.Install(m_wifiApNodes.Get(0));
-    ApplicationContainer serverApp2 = echoServer.Install(m_wifiApNodes.Get(1));
-    serverApp1.Start(Seconds(0.0));
-    serverApp1.Stop(Seconds(m_simulationTime));
-    serverApp2.Start(Seconds(0.0));
-    serverApp2.Stop(Seconds(m_simulationTime));
-
-    UdpEchoClientHelper echoClient1(Ipv4Address("10.1.1.1"), echoPort);
-    echoClient1.SetAttribute("MaxPackets", UintegerValue(4294967295u));
-    echoClient1.SetAttribute("Interval", TimeValue(Seconds(1.0)));
-    echoClient1.SetAttribute("PacketSize", UintegerValue(1024));
-
-    UdpEchoClientHelper echoClient2(Ipv4Address("10.1.1.2"), echoPort);
-    echoClient2.SetAttribute("MaxPackets", UintegerValue(4294967295u));
-    echoClient2.SetAttribute("Interval", TimeValue(Seconds(1.0)));
-    echoClient2.SetAttribute("PacketSize", UintegerValue(1024));
-
-    ApplicationContainer clientAppsA, clientAppsB;
-    for (uint32_t i = 0; i < m_groupA.GetN(); ++i)
-    {
-        clientAppsA.Add(echoClient1.Install(m_groupA.Get(i)));
+    uint16_t port = 7;
+    UdpEchoServerHelper server(port);
+    for (uint32_t i = 0; i < m_numAp; ++i) {
+        auto srv = server.Install(m_wifiApNodes.Get(i));
+        srv.Start(Seconds(0.0));
+        srv.Stop(Seconds(m_simulationTime));
     }
-    for (uint32_t i = 0; i < m_groupB.GetN(); ++i)
-    {
-        clientAppsB.Add(echoClient2.Install(m_groupB.Get(i)));
+
+    for (uint32_t i = 0; i < m_numAp; ++i) {
+        // look up AP’s IP
+        Ipv4Address apAddr = m_wifiApNodes.Get(i)
+                ->GetObject<Ipv4>()
+                ->GetAddress(1,0)
+                .GetLocal();
+        UdpEchoClientHelper client(apAddr, port);
+        client.SetAttribute("MaxPackets", UintegerValue(0xFFFFFFFF));
+        client.SetAttribute("Interval", TimeValue(Seconds(1.0)));
+        client.SetAttribute("PacketSize", UintegerValue(1024));
+
+        auto apps = client.Install(m_groups[i]);
+        apps.Start(Seconds(1.0));
+        apps.Stop(Seconds(m_simulationTime));
     }
-    clientAppsA.Start(Seconds(1.0));
-    clientAppsA.Stop(Seconds(m_simulationTime));
-    clientAppsB.Start(Seconds(1.0));
-    clientAppsB.Stop(Seconds(m_simulationTime));
 }
 
 void
 HandoverExperiment::SetupTracing()
 {
-    // Create NetAnim XML output.
+#ifdef WITH_NETANIM
     m_anim = new AnimationInterface("data/handover/netanim.xml");
-    // Fixed colors for AP nodes.
-    m_anim->UpdateNodeColor(m_wifiApNodes.Get(0)->GetId(), 0, 0, 255);   // Dark blue.
-    m_anim->UpdateNodeColor(m_wifiApNodes.Get(1)->GetId(), 255, 0, 0);   // Dark red.
-
-    // Enable PCAP generation.
-    YansWifiPhyHelper wifiPhyHelper;
-    for (uint32_t i = 0; i < m_apDevices.GetN(); ++i)
-    {
-        std::string fileName = "data/handover/ap_" + std::to_string(i) + ".pcap";
-        wifiPhyHelper.EnablePcap(fileName, m_apDevices.Get(i), true, YansWifiPhyHelper::DLT_IEEE802_11_RADIO);
+    // color APs dark-blue / dark-red
+    for (uint32_t i = 0; i < m_numAp; ++i) {
+      uint8_t r = (i==0?0:255), g = 0, b = (i==0?255:0);
+      m_anim->UpdateNodeColor(
+        m_wifiApNodes.Get(i)->GetId(), r, g, b);
     }
-    for (uint32_t i = 0; i < m_staDevices.GetN(); ++i)
-    {
-        std::string fileName = "data/handover/sta_" + std::to_string(i) + ".pcap";
-        wifiPhyHelper.EnablePcap(fileName, m_staDevices.Get(i), true, YansWifiPhyHelper::DLT_IEEE802_11_RADIO);
+#endif
+
+    YansWifiPhyHelper phy;
+    for (uint32_t i = 0; i < m_apDevices.GetN(); ++i) {
+        phy.EnablePcap("data/handover/hand_ap"+std::to_string(i),
+                       m_apDevices.Get(i), true);
+    }
+    for (uint32_t i = 0; i < m_staDevices.GetN(); ++i) {
+        phy.EnablePcap("data/handover/hand_sta"+std::to_string(i),
+                       m_staDevices.Get(i), true);
     }
 }
 
@@ -271,61 +329,59 @@ HandoverExperiment::RestoreNodeTriggered(uint32_t nodeId)
 void
 HandoverExperiment::CheckRssiAndTriggerHandover()
 {
-    // Retrieve AP positions.
-    Vector ap1Pos = m_wifiApNodes.Get(0)->GetObject<MobilityModel>()->GetPosition();
-    Vector ap2Pos = m_wifiApNodes.Get(1)->GetObject<MobilityModel>()->GetPosition();
+    // get AP positions
+    std::vector<Vector> apPos(m_numAp);
+    for (uint32_t i = 0; i < m_numAp; ++i) {
+        apPos[i] = m_wifiApNodes.Get(i)
+                ->GetObject<MobilityModel>()
+                ->GetPosition();
+    }
 
-    // Combine pedestrian nodes.
-    NodeContainer allPedestrians;
-    allPedestrians.Add(m_groupA);
-    allPedestrians.Add(m_groupB);
+    // for each pedestrian
+    for (auto &grp : m_groups) {
+        for (uint32_t j = 0; j < grp.GetN(); ++j) {
+            Ptr<Node> node = grp.Get(j);
+            auto pos = node->GetObject<MobilityModel>()->GetPosition();
+            uint32_t id = node->GetId();
 
-    for (uint32_t i = 0; i < allPedestrians.GetN(); ++i)
-    {
-        Ptr<Node> node = allPedestrians.Get(i);
-        uint32_t nodeId = node->GetId();
-        Vector pos = node->GetObject<MobilityModel>()->GetPosition();
-        double rssi1 = EstimateRssi(pos, ap1Pos);
-        double rssi2 = EstimateRssi(pos, ap2Pos);
-        int currentAssociation = m_nodeAssociation[nodeId];
+            // compute RSSIs
+            std::vector<double> rssis(m_numAp);
+            for (uint32_t i = 0; i < m_numAp; ++i) {
+                rssis[i] = EstimateRssi(pos, apPos[i]);
+            }
 
-        if (currentAssociation == 1)
-        {
-            // Currently associated with AP1.
-            if (rssi2 > (rssi1 + m_handoverMargin) && !m_nodeTriggered[nodeId])
-            {
-                NS_LOG_INFO("Node " << nodeId << " handing over from AP1 to AP2.");
-                m_nodeAssociation[nodeId] = 2;
-                m_nodeTriggered[nodeId] = true;
-                m_anim->UpdateNodeColor(nodeId, 255, 150, 150); // Light red.
-                Simulator::Schedule(Seconds(5.0), &HandoverExperiment::RestoreNodeTriggered, this, nodeId);
+            int cur = m_nodeAssociation[id], best = cur;
+            for (int i = 0; i < (int)m_numAp; ++i) {
+                if (rssis[i] > rssis[best] + m_handoverMargin) {
+                    best = i;
+                }
             }
-            else
-            {
-                m_anim->UpdateNodeColor(nodeId, 150, 150, 255); // Ensure light blue if still with AP1.
-            }
-        }
-        else if (currentAssociation == 2)
-        {
-            // Currently associated with AP2.
-            if (rssi1 > (rssi2 + m_handoverMargin) && !m_nodeTriggered[nodeId])
-            {
-                NS_LOG_INFO("Node " << nodeId << " handing over from AP2 to AP1.");
-                m_nodeAssociation[nodeId] = 1;
-                m_nodeTriggered[nodeId] = true;
-                m_anim->UpdateNodeColor(nodeId, 150, 150, 255); // Light blue.
-                Simulator::Schedule(Seconds(5.0), &HandoverExperiment::RestoreNodeTriggered, this, nodeId);
-            }
-            else
-            {
-                m_anim->UpdateNodeColor(nodeId, 255, 150, 150); // Ensure light red if still with AP2.
+
+            if (best != cur && !m_nodeTriggered[id]) {
+                NS_LOG_UNCOND(Simulator::Now().GetSeconds()
+                << "s: Node " << id
+                << " handover AP" << cur
+                << "→AP" << best);
+                m_nodeAssociation[id] = best;
+                m_nodeTriggered [id] = true;
+                m_handoverCount [id]++;
+#ifdef WITH_NETANIM
+                // light‐color the new AP color
+                uint8_t r = (best==0?150:255),
+                        g = 150,
+                        b = (best==0?255:150);
+                m_anim->UpdateNodeColor(id, r, g, b);
+#endif
+                Simulator::Schedule(Seconds(5.0),
+                                    &HandoverExperiment::RestoreNodeTriggered,
+                                    this, id);
             }
         }
     }
 
-    // Reschedule check every second.
-    if (Simulator::Now().GetSeconds() < m_simulationTime)
-    {
-        Simulator::Schedule(Seconds(1.0), &HandoverExperiment::CheckRssiAndTriggerHandover, this);
+    if (Simulator::Now().GetSeconds() < m_simulationTime) {
+        Simulator::Schedule(Seconds(1.0),
+                            &HandoverExperiment::CheckRssiAndTriggerHandover,
+                            this);
     }
 }

--- a/src/experiments/HandoverExperiment.hpp
+++ b/src/experiments/HandoverExperiment.hpp
@@ -15,6 +15,8 @@
 #include "ns3/wifi-module.h"
 #include "ns3/applications-module.h"
 #include <map>
+#include <vector>
+#include <string>
 
 class HandoverExperiment : public monadcount_sim::core::Scenario
 {
@@ -23,42 +25,32 @@ public:
     virtual void Run(monadcount_sim::core::ScenarioEnvironment &env);
 
 protected:
-    // Simulation parameters.
-    uint32_t m_numPedestrians;
-    double m_simulationTime;
-    double m_roomLength;
-    double m_roomWidth;
+    // Configurable parameters
+    uint32_t            m_numAp;
+    uint32_t            m_numPedestrians;
+    double              m_simulationTime;
+    double              m_roomLength;
+    double              m_roomWidth;
+    double              m_handoverMargin;
+    double              m_txPower_dBm;
+    double              m_pathLossExponent;
+    std::string         m_mobilityModel;
 
-    // Additional simulation parameters.
-    double m_handoverMargin;
-    double m_txPower_dBm;
-    double m_pathLossExponent;
+    // Nodes & devices
+    ns3::NodeContainer              m_wifiApNodes;
+    std::vector<ns3::NodeContainer> m_groups;
+    ns3::NetDeviceContainer         m_apDevices;
+    ns3::NetDeviceContainer         m_staDevices;
 
-    // Node containers for APs and pedestrian groups.
-    ns3::NodeContainer m_wifiApNodes;
-    ns3::NodeContainer m_groupA;
-    ns3::NodeContainer m_groupB;
+    // Handover state
+    std::map<uint32_t,int>      m_nodeAssociation;
+    std::map<uint32_t,bool>     m_nodeTriggered;
+    std::map<uint32_t,uint32_t> m_handoverCount;
 
-    // NetDevice containers to store installed devices.
-    ns3::NetDeviceContainer m_apDevices;
-    ns3::NetDeviceContainer m_staDevices;
+    // NetAnim
+    ns3::AnimationInterface*     m_anim;
 
-    // Pointers to the AP MAC objects.
-    ns3::Ptr<ns3::ApWifiMac> m_ap1Mac;
-    ns3::Ptr<ns3::ApWifiMac> m_ap2Mac;
-
-    // Handover trigger flags.
-    bool m_handoverTriggeredAP1;
-    bool m_handoverTriggeredAP2;
-
-    std::map<uint32_t, int> m_nodeAssociation;
-    std::map<uint32_t, bool> m_nodeTriggered;
-
-
-    // Animation interface pointer for NetAnim.
-    ns3::AnimationInterface* m_anim;
-
-    // Private helper functions.
+    // Helpers
     double EstimateRssi(const ns3::Vector &stationPos, const ns3::Vector &apPos) const;
     void SetupNodes();
     void SetupWifi();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include "experiments/HandoverExperiment.hpp"
 #include "experiments/GaussMarkovHandoverExperiment.hpp"
 #include <system_error>
+#include <filesystem>
 
 namespace fs = std::filesystem;
 using namespace ns3;
@@ -16,7 +17,7 @@ void RegisterScenarios() {
     factory.RegisterScenario<BasicExperiment>("basic");
     factory.RegisterScenario<DoorToDoorExperiment>("doortodoor");
     factory.RegisterScenario<HandoverExperiment>("handover");
-    factory.RegisterScenario<GaussMarkovHandoverExperiment>("gauss-markov-handover");
+    //factory.RegisterScenario<GaussMarkovHandoverExperiment>("gauss-markov-handover");
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
### Changelog for `HandoverExperiment` rewrite  

---

#### Summary  
- Complete refactor of **HandoverExperiment.cpp** to support an arbitrary number of APs and pedestrian sub‑groups while preserving the original RSSI‑margin hand‑over logic.  
- NetAnim is now optional; all references are wrapped in `#ifdef WITH_NETANIM` because NetAnim failed to build and couldn't get it to run on my system.  
- `GaussMarkovHandoverExperiment.cpp` has been made obsolete; the generic experiment now supports the Gauss–Markov model directly (see constructor parameter).  
- More parameters, saner defaults and a per‑node hand‑over counter were added, but additional test coverage is still required (see “Next steps”).

---

#### What changed, in detail

| Area | Old code | New code |
|------|----------|----------|
| Scalability | Fixed to 2 APs / 2 pedestrian groups | `m_numAp` (default 5) creates *N* APs and splits pedestrians across a `std::vector<NodeContainer> m_groups` |
| Mobility | Hard‑coded `ConstantVelocity` with small Y noise | Selectable in the constructor via `m_mobilityModel` string (`ConstantVelocity`, `RandomWalk2d`, `GaussMarkov`, `Waypoint`); default is `GaussMarkov` |
| Parameters | Mostly literals | Additional members (`m_numAp`, `m_numPedestrians`, `m_handoverMargin`, etc.). A commented‑out `CommandLine` stub remains (not working), and at present all tuning is done in source. |
| RSSI check | Two‑way comparison | Loop over `m_numAp`, selects best RSSI within the margin |
| NetAnim | Mandatory, broke CI if the library was missing | Guarded by `#ifdef WITH_NETANIM` |
| Tracing colours | Single blue/red pair | Colour derived from AP index (dark for APs, lighter for STAs after hand‑over) |
| File layout | Separate Gauss‑Markov experiment file | Removed; functionality folded into the main experiment |

#### Known limitations

1. Only limited manual runs have been performed with the mobility options; needs more testing.  
2. Dense AP layouts (< 5 m spacing) may cause ping‑pong hand‑overs because the margin logic is unchanged.

---

#### Next steps
- Run focused **visual sanity checks** for each mobility model to confirm pedestrian trajectories, AP placement and colour‑coded hand‑overs look reasonable.  

